### PR TITLE
Fix skillbook showing masterybook text

### DIFF
--- a/src/channel_server/inventory_handler.cpp
+++ b/src/channel_server/inventory_handler.cpp
@@ -205,7 +205,8 @@ auto inventory_handler::use_skillbook(ref_ptr<player> player, packet_reader &rea
 	}
 
 	if (skill_id != 0) {
-		player->send_map(packets::inventory::use_skillbook(player->get_id(), skill_id, new_max_level, true, succeed));
+		bool is_mastery_book = game_logic_utilities::get_item_type(item_id) == constant::item::type::item_mastery_book;
+		player->send_map(packets::inventory::use_skillbook(player->get_id(), is_mastery_book, skill_id, new_max_level, true, succeed));
 	}
 }
 

--- a/src/channel_server/inventory_packet.cpp
+++ b/src/channel_server/inventory_packet.cpp
@@ -105,18 +105,20 @@ SPLIT_PACKET_IMPL(send_chalkboard_update, game_player_id player_id, const string
 	return builder;
 }
 
-SPLIT_PACKET_IMPL(use_skillbook, game_player_id player_id, game_skill_id skill_id, int32_t new_max_level, bool use, bool succeed) {
+SPLIT_PACKET_IMPL(use_skillbook, game_player_id player_id, bool is_mastery_book, game_skill_id skill_id, int32_t new_max_level, bool use, bool succeed) {
 	split_packet_builder builder;
 	builder.player
 		.add<packet_header>(SMSG_SKILLBOOK)
 		.add<game_player_id>(player_id)
-		.add<int8_t>(1) // Number of skills? Maybe just padding or random boolean
+		.add<bool>(is_mastery_book)
 		.add<game_skill_id>(skill_id)
 		.add<int32_t>(new_max_level)
 		.add<bool>(use)
 		.add<bool>(succeed);
 
-	builder.map.add_buffer(builder.player);
+	if (use) {
+		builder.map.add_buffer(builder.player);
+	}
 	return builder;
 }
 

--- a/src/channel_server/inventory_packet.hpp
+++ b/src/channel_server/inventory_packet.hpp
@@ -86,7 +86,7 @@ namespace vana {
 				SPLIT_PACKET(stop_chair, game_player_id player_id, bool seat_taken);
 				SPLIT_PACKET(use_scroll, game_player_id player_id, int8_t succeed, bool destroy, bool legendary_spirit);
 				SPLIT_PACKET(send_chalkboard_update, game_player_id player_id, const string &msg);
-				SPLIT_PACKET(use_skillbook, game_player_id player_id, game_skill_id skill_id, int32_t new_max_level, bool use, bool succeed);
+				SPLIT_PACKET(use_skillbook, game_player_id player_id, bool is_mastery_book, game_skill_id skill_id, int32_t new_max_level, bool use, bool succeed);
 				SPLIT_PACKET(use_item_effect, game_player_id player_id, game_item_id item_id);
 				SPLIT_PACKET(send_reward_item_animation, game_player_id player_id, game_item_id item_id, const string &effect);
 				PACKET(inventory_operation, bool unk, const vector<inventory_packet_operation> &operations);

--- a/src/common/constant/item/type.hpp
+++ b/src/common/constant/item/type.hpp
@@ -59,6 +59,7 @@ namespace vana {
 					mount = 190,
 					item_arrow = 206,
 					item_star = 207,
+					item_mastery_book = 229,
 					item_bullet = 233,
 					item_monster_card = 238,
 					weather_cash = 512,


### PR DESCRIPTION
This will fix showing 'Mastery Book' when a regular skillbook is used
Also it will not broadcast to the whole map that the book/item was not used (GMS-like behaviour)
