### PR TITLE
Fix channelserver crashing when disconnected from worldserver

### DIFF
--- a/src/channel_server/channel_server.cpp
+++ b/src/channel_server/channel_server.cpp
@@ -320,7 +320,9 @@ auto channel_server::get_online_id() const -> int32_t {
 }
 
 auto channel_server::send_world(const packet_builder &builder) -> void {
-	m_world_connection->send(builder);
+	if (m_world_connection != nullptr) {
+		m_world_connection->send(builder);
+	}
 }
 
 auto channel_server::set_scrolling_header(const string &message) -> void {

--- a/src/channel_server/player_data_provider.cpp
+++ b/src/channel_server/player_data_provider.cpp
@@ -235,7 +235,9 @@ auto player_data_provider::stop_following(ref_ptr<player> follower) -> void {
 }
 
 auto player_data_provider::disconnect() -> void {
-	for (auto &kvp : m_players) {
+	auto m_players_copy = hash_map<game_player_id, ref_ptr<player>>(m_players);
+
+	for (auto &kvp : m_players_copy) {
 		if (auto player = kvp.second) {
 			player->disconnect();
 		}

--- a/src/channel_server/player_data_provider.cpp
+++ b/src/channel_server/player_data_provider.cpp
@@ -235,7 +235,7 @@ auto player_data_provider::stop_following(ref_ptr<player> follower) -> void {
 }
 
 auto player_data_provider::disconnect() -> void {
-	auto m_players_copy = hash_map<game_player_id, ref_ptr<player>>(m_players);
+	auto m_players_copy = m_players;
 
 	for (auto &kvp : m_players_copy) {
 		if (auto player = kvp.second) {


### PR DESCRIPTION
Caused by:
- using a shared_ptr that is reset
- disconnecting players without using a copy of the player hashmap (hashmap modified after first iteration because of player disconnect code)
