### PR TITLE
Add advanced !packet command

### DIFF
--- a/src/channel_server/chat_handler_functions.cpp
+++ b/src/channel_server/chat_handler_functions.cpp
@@ -636,6 +636,23 @@ auto chat_handler_functions::initialize() -> void {
 	command.syntax = "<${view | reset | set}> <${mobexp | dropmeso | questexp | drop | globaldrop | globaldropmeso}> [#new rate]";
 	command.notes.push_back("Allows the viewing or setting of rates on the current world");
 	g_command_list["rates"] = command.add_to_map();
+
+	command.command = &management_functions::packet;
+	command.syntax = "<hex string and/or special placeholders>";
+	command.notes.push_back("Send a packet to yourself");
+	command.notes.push_back("This command also supports placeholders for making sending packets easier.");
+	command.notes.push_back("Packets of 0 or 1 byte will not be sent.");
+	command.notes.push_back("If you want to send B0 - B9, you need to write it with a capital.");
+	command.notes.push_back("Supported placeholders:");
+	command.notes.push_back(" \"text\": write 'text' as a string (including size)");
+	command.notes.push_back(" lNNN: write an int64 (long), where NNN = number from " + utilities::str::lexical_cast<string>(INT64_MIN) + " to "  + utilities::str::lexical_cast<string>(INT64_MAX) + " inclusive");
+	command.notes.push_back(" iNNN: write an int32 (int), where NNN = number from " + utilities::str::lexical_cast<string>(INT32_MIN) + " to "  + utilities::str::lexical_cast<string>(INT32_MAX) + " inclusive");
+	command.notes.push_back(" sNNN: write an int16 (short), where NNN = number from " + utilities::str::lexical_cast<string>(INT16_MIN) + " to "  + utilities::str::lexical_cast<string>(INT16_MAX) + " inclusive");
+	command.notes.push_back(" bNNN: write an int8 (byte), where NNN = number from " + utilities::str::lexical_cast<string>(INT8_MIN) + " to "  + utilities::str::lexical_cast<string>(INT8_MAX) + " inclusive");
+	command.notes.push_back("Example:");
+	command.notes.push_back(" !packet 7E00 b3 \"dojang/end/clear\"");
+	command.notes.push_back(" !packet 9400 i0 b1 \"This is a message from a gm, probably\" b0 \"Vana\"");
+	g_command_list["packet"] = command.add_to_map();
 	#pragma endregion
 
 	#pragma region GM Level 0

--- a/src/channel_server/chat_handler_functions.cpp
+++ b/src/channel_server/chat_handler_functions.cpp
@@ -645,10 +645,10 @@ auto chat_handler_functions::initialize() -> void {
 	command.notes.push_back("If you want to send B0 - B9, you need to write it with a capital.");
 	command.notes.push_back("Supported placeholders:");
 	command.notes.push_back(" \"text\": write 'text' as a string (including size)");
-	command.notes.push_back(" lNNN: write an int64 (long), where NNN = number from " + utilities::str::lexical_cast<string>(INT64_MIN) + " to "  + utilities::str::lexical_cast<string>(INT64_MAX) + " inclusive");
-	command.notes.push_back(" iNNN: write an int32 (int), where NNN = number from " + utilities::str::lexical_cast<string>(INT32_MIN) + " to "  + utilities::str::lexical_cast<string>(INT32_MAX) + " inclusive");
-	command.notes.push_back(" sNNN: write an int16 (short), where NNN = number from " + utilities::str::lexical_cast<string>(INT16_MIN) + " to "  + utilities::str::lexical_cast<string>(INT16_MAX) + " inclusive");
-	command.notes.push_back(" bNNN: write an int8 (byte), where NNN = number from " + utilities::str::lexical_cast<string>(INT8_MIN) + " to "  + utilities::str::lexical_cast<string>(INT8_MAX) + " inclusive");
+	command.notes.push_back(" lNNN: write an int64 (long), where NNN = number from " + utilities::str::lexical_cast<string>(INT64_MIN) + " to " + utilities::str::lexical_cast<string>(INT64_MAX) + " inclusive");
+	command.notes.push_back(" iNNN: write an uint32 (unsigned int), where NNN = number from 0 to " + utilities::str::lexical_cast<string>(UINT32_MAX) + " inclusive");
+	command.notes.push_back(" sNNN: write an uint16 (unsigned short), where NNN = number from 0 to " + utilities::str::lexical_cast<string>(UINT16_MAX) + " inclusive");
+	command.notes.push_back(" bNNN: write an uint8 (unsigned byte), where NNN = number from 0 to " + utilities::str::lexical_cast<string>(UINT8_MAX) + " inclusive");
 	command.notes.push_back("Example:");
 	command.notes.push_back(" !packet 7E00 b3 \"dojang/end/clear\"");
 	command.notes.push_back(" !packet 9400 i0 b1 \"This is a message from a gm, probably\" b0 \"Vana\"");

--- a/src/channel_server/management_functions.cpp
+++ b/src/channel_server/management_functions.cpp
@@ -821,10 +821,6 @@ auto management_functions::rates(ref_ptr<player> player, const game_chat &args) 
 }
 
 auto management_functions::packet(ref_ptr<player> player, const game_chat &args) -> chat_result {
-	auto is_number = [](char character) {
-		return (character >= '0' && character <= '9');
-	};
-
 	auto is_hex = [](char character) {
 		return (character >= 'a' && character <= 'f') ||
 				(character >= 'A' && character <= 'F') ||
@@ -873,22 +869,22 @@ auto management_functions::packet(ref_ptr<player> player, const game_chat &args)
 					packet.add<int64_t>(value);
 				}
 				else if (character == 'i') {
-					if (value >= INT32_MAX || value <= INT32_MIN) {
-						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT32_MIN and INT32_MAX");
+					if (value < 0 || value >= UINT32_MAX) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between 0 and " + lexical_cast<string>(UINT32_MAX));
 						return chat_result::handled_display;
 					}
 					packet.add<int32_t>(static_cast<int32_t>(value));
 				}
 				else if (character == 's') {
-					if (value >= INT16_MAX || value <= INT16_MIN) {
-						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT16_MIN and INT16_MAX");
+					if (value < 0 || value >= UINT16_MAX) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between 0 and " + lexical_cast<string>(UINT16_MAX));
 						return chat_result::handled_display;
 					}
 					packet.add<int16_t>(static_cast<int16_t>(value));
 				}
 				else if (character == 'b') {
-					if (value >= INT8_MAX || value <= INT8_MIN) {
-						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT8_MIN and INT8_MAX");
+					if (value < 0 || value >= UINT8_MAX) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between 0 and " + lexical_cast<string>(UINT8_MAX));
 						return chat_result::handled_display;
 					}
 					packet.add<int8_t>(static_cast<int8_t>(value));
@@ -935,14 +931,14 @@ auto management_functions::packet(ref_ptr<player> player, const game_chat &args)
 				}
 
 				packet.add_bytes(args.substr(i, string_length));
-				
+
 				i += string_length;
 				continue;
 			}
 
 			// Parsed nothing. huh?
-			
-			chat_handler_functions::show_info(player, "Character is invalid length at " + lexical_cast<string>(i));
+
+			chat_handler_functions::show_info(player, "Character is invalid at " + lexical_cast<string>(i));
 			return chat_result::handled_display;
 		}
 
@@ -962,7 +958,6 @@ auto management_functions::packet(ref_ptr<player> player, const game_chat &args)
 		player->send(packet);
 		return chat_result::handled_display;
 	}
-
 
 	return chat_result::show_syntax;
 }

--- a/src/channel_server/management_functions.cpp
+++ b/src/channel_server/management_functions.cpp
@@ -820,5 +820,152 @@ auto management_functions::rates(ref_ptr<player> player, const game_chat &args) 
 	return chat_result::handled_display;
 }
 
+auto management_functions::packet(ref_ptr<player> player, const game_chat &args) -> chat_result {
+	auto is_number = [](char character) {
+		return (character >= '0' && character <= '9');
+	};
+
+	auto is_hex = [](char character) {
+		return (character >= 'a' && character <= 'f') ||
+				(character >= 'A' && character <= 'F') ||
+				(character >= '0' && character <= '9');
+	};
+
+	using utilities::str::lexical_cast;
+	if (!args.empty()) {
+		// Build packet
+		packet_builder packet;
+
+		// Build raw hex string from cool format
+		// iNNNN = add int
+		// sNNNN = add short
+		// lNNNN = add long
+		// bNN   = add byte
+		// "...." = add string
+
+		size_t args_length = args.length();
+		for (size_t i = 0; i < args_length; i++) {
+			char character = args.at(i);
+
+			size_t next_space = args.find(' ', i + 1);
+			if (next_space == game_chat::npos) {
+				next_space = args_length;
+			}
+			size_t string_length = (next_space - 1) - (i - 1);
+
+			if (character == ' ') continue;
+
+			// Check for integer value
+
+			if (character == 'i' ||
+				character == 's' ||
+				character == 'l' ||
+				character == 'b') {
+
+				game_chat value_string;
+				int64_t value = 0;
+				if (string_length != 0) {
+					value_string = args.substr(i + 1, string_length - 1);
+					value = utilities::str::atoli(value_string.c_str());
+				}
+
+				if (character == 'l') {
+					packet.add<int64_t>(value);
+				}
+				else if (character == 'i') {
+					if (value >= INT32_MAX || value <= INT32_MIN) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT32_MIN and INT32_MAX");
+						return chat_result::handled_display;
+					}
+					packet.add<int32_t>(static_cast<int32_t>(value));
+				}
+				else if (character == 's') {
+					if (value >= INT16_MAX || value <= INT16_MIN) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT16_MIN and INT16_MAX");
+						return chat_result::handled_display;
+					}
+					packet.add<int16_t>(static_cast<int16_t>(value));
+				}
+				else if (character == 'b') {
+					if (value >= INT8_MAX || value <= INT8_MIN) {
+						chat_handler_functions::show_info(player, "Number '" + value_string + "' is not between INT8_MIN and INT8_MAX");
+						return chat_result::handled_display;
+					}
+					packet.add<int8_t>(static_cast<int8_t>(value));
+				}
+
+				i += string_length;
+				continue;
+			}
+
+			if (character == '"') {
+				size_t next_quote = args.find('"', i + 1);
+				if (next_quote == game_chat::npos) {
+					chat_handler_functions::show_info(player, "String not terminated");
+					return chat_result::handled_display;
+				}
+
+				size_t string_length = (next_quote - 1) - i;
+
+				if (string_length == 0) {
+					// no text
+					packet.add<game_chat>("");
+				}
+				else {
+					packet.add<game_chat>(args.substr(i + 1, string_length));
+				}
+
+				i = next_quote;
+				continue;
+			}
+
+			if (is_hex(character)) {
+				if ((string_length % 2) != 0) {
+					chat_handler_functions::show_info(player, "Hex is invalid length at " + lexical_cast<string>(i));
+					return chat_result::handled_display;
+				}
+
+				// quick check
+				for (size_t j = i; j < (i + string_length); j++) {
+					char hex_char = args.at(j);
+					if (!is_hex(hex_char)) {
+						chat_handler_functions::show_info(player, "Hex is invalid length at " + lexical_cast<string>(j));
+						return chat_result::handled_display;
+					}
+				}
+
+				packet.add_bytes(args.substr(i, string_length));
+				
+				i += string_length;
+				continue;
+			}
+
+			// Parsed nothing. huh?
+			
+			chat_handler_functions::show_info(player, "Character is invalid length at " + lexical_cast<string>(i));
+			return chat_result::handled_display;
+		}
+
+		// Make sure we are not consuming an empty string
+		// or a string that does not match a correct packet length
+		if (packet.get_size() < 2) {
+			return chat_result::show_syntax;
+		}
+
+		channel_server::get_instance().log(log_type::gm_command, [&](out_stream &log) {
+			log << "GM " << player->get_name()
+				<< " sent packet to self: " << std::endl
+				<< "raw: " << packet << std::endl
+				<< "cmd: " << args;
+		});
+
+		player->send(packet);
+		return chat_result::handled_display;
+	}
+
+
+	return chat_result::show_syntax;
+}
+
 }
 }

--- a/src/channel_server/management_functions.hpp
+++ b/src/channel_server/management_functions.hpp
@@ -48,6 +48,7 @@ namespace vana {
 			auto unban(ref_ptr<player> player, const game_chat &args) -> chat_result;
 			auto rehash(ref_ptr<player> player, const game_chat &args) -> chat_result;
 			auto rates(ref_ptr<player> player, const game_chat &args) -> chat_result;
+			auto packet(ref_ptr<player> player, const game_chat &args) -> chat_result;
 		}
 	}
 }

--- a/src/common/string_utilities.cpp
+++ b/src/common/string_utilities.cpp
@@ -76,10 +76,24 @@ auto run_enum(const string &enum_text, function<void (const string &)> func) -> 
 }
 
 auto atoli(const char *str) -> int64_t {
+	// Discard whitespaces
+	while (isspace(*str)) str++;
+
+	bool negative = false;
+	if (*str == '+') str++;
+	else if (*str == '-') {
+		negative = true;
+		str++;
+	}
+	
 	int64_t result = 0;
+	
 	while (*str >= '0' && *str <= '9') {
 		result = (result * 10) + (*str++ - '0');
 	}
+
+	if (negative) result *= -1;
+
 	return result;
 }
 


### PR DESCRIPTION
This command supports the following 'placeholders':
- `lNNN` for writing int64
- `iNNN` for writing uint32
- `sNNN` for writing uint16
- `bNNN` for writing uint8
- `"text"` for writing a string

Also i fixed/expanded the atoli() function. It now acts more like atoi, where it has to remove whitespaces (using isspace) first, then check for the plus/minus sign, and after that finally parse the numbers. After that, make the value negative, of course.
